### PR TITLE
Update GuzzleHandler.php

### DIFF
--- a/src/GuzzleHandler.php
+++ b/src/GuzzleHandler.php
@@ -93,7 +93,7 @@ class GuzzleHandler
             'status' => null,
             'reason' => null,
             'headers' => [],
-            'effective_url' => null,
+            'effective_url' => '',
             'body' => null,
             'transfer_stats' => [
                 'url' => null,

--- a/tests/GuzzleHandlerTest.php
+++ b/tests/GuzzleHandlerTest.php
@@ -114,5 +114,6 @@ class GuzzleHandlerTest extends TestCase
         ]);
 
         $this->assertEquals($exception, $response['error']);
+        $this->assertSame($response['effective_url'], '');
     }
 }


### PR DESCRIPTION
This updates the `emptyResposne` return value to use an empty string for `effective_url` instead of `null`.  There was a `TypeError` being thrown by PHP due to Guzzle using the `effective_url` in a function that only allowed `string`.

Closes #10